### PR TITLE
Add CI with cargo fmt and clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,21 @@
+name: Rust formatting and linting
+
+on: push
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt-and-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run rustfmt
+        run: |
+          cargo fmt --manifest-path rust_api/Cargo.toml
+      - name: Run clippy
+        run: |
+          cargo clippy --manifest-path rust_api/Cargo.toml -- -W clippy::correctness -D warnings


### PR DESCRIPTION
Add a GitHub Actions workflow that runs cargo fmt and clippy as to make sure our Rust code looks awesome.